### PR TITLE
Add C++ build to Coverity scan job

### DIFF
--- a/.ci/pipeline/nightly.yml
+++ b/.ci/pipeline/nightly.yml
@@ -53,7 +53,8 @@ jobs:
       conda activate CB
       pip install -r dependencies-dev
       export DALROOT=$CONDA_PREFIX
-      $(COVERITY_TOOL_HOME)/bin/cov-build --dir cov-int -- python setup.py build_ext --inplace
+            $(COVERITY_TOOL_HOME)/bin/cov-build --dir cov-int --no-command --fs-capture-search .
+            $(COVERITY_TOOL_HOME)/bin/cov-build --dir cov-int -- python setup.py build_ext --inplace
       zip -r daal4py.zip cov-int
     displayName: 'Perform Coverity scan'
   - script: |


### PR DESCRIPTION
## Summary
- modify Coverity job to compile the C++ extension before running the scan

## Testing
- `pytest -k "" -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pre-commit run --files .ci/pipeline/nightly.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68426d5e18e8832b913af5f65def7225

## Summary by Sourcery

Integrate the C++ extension build into the nightly Coverity scan pipeline by configuring a conda environment, installing development dependencies, and invoking the extension build before running the scan

CI:
- Configure conda-forge channel and strict channel priority in the CI job
- Update conda, create and activate a dedicated environment with required C++ dependencies
- Install development requirements via pip and set DALROOT for build
- Invoke cov-build on the C++ extension build step using `python setup.py build_ext --inplace`