### PR TITLE
Fix delete on void pointer

### DIFF
--- a/src/daal4py.cpp
+++ b/src/daal4py.cpp
@@ -86,7 +86,7 @@ void rawp_free_cap(PyObject * cap)
     void * rp = PyCapsule_GetPointer(cap, NULL);
     if (rp)
     {
-        delete[] rp;
+        ::operator delete[](rp);
         rp = NULL;
     }
 }


### PR DESCRIPTION
## Summary
- fix undefined behavior by using `operator delete[]` when freeing raw pointers

## Testing
- `pytest -k "" -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684910a8335c832b9c1afc8cbf882827